### PR TITLE
Allow custom Returners

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,15 @@ gem "lita-salt"
 
 ## Configuration
 
-### Required attributes
+### Required
 
 * `url` (String) – The location of the running salt-api service.
 * `username` (String) – The username used to authenticate with salt-api.
 * `password` (String) – The password used to authenticate with salt-api.
+
+### Optional
+
+* `returner` (String) – A Saltstack returner you'd like to use. (uses default if unset)
 
 ### Example
 

--- a/lib/lita/handlers/salt.rb
+++ b/lib/lita/handlers/salt.rb
@@ -14,6 +14,7 @@ module Lita
       config :url, required: true
       config :username, required: true
       config :password, required: true
+      config :returner, required: false
 
 
 
@@ -100,7 +101,7 @@ module Lita
         if expired
           authenticate
         end
-        body = build_runner('manage.up')
+        body = build_runner('manage.up', returner)
         response = make_request('/', body)
         if response.status == 200
           msg.reply response.body
@@ -113,7 +114,7 @@ module Lita
         if expired
           authenticate
         end
-        body = build_runner('manage.down')
+        body = build_runner('manage.down', returner)
         response = make_request('/', body)
         if response.status == 200
           msg.reply response.body
@@ -132,7 +133,7 @@ module Lita
         if what.nil?
           msg.reply "Missing service name"
         else
-          body = build_local(where, "#{__callee__}.#{task}", what)
+          body = build_local(where, "#{__callee__}.#{task}", what, returner)
           response = make_request('/', body)
           msg.reply process_response(response)
         end
@@ -148,7 +149,7 @@ module Lita
         if what.nil?
           msg.reply "Missing job name"
         else
-          body = build_local(where, "#{__callee__}.#{task}", what)
+          body = build_local(where, "#{__callee__}.#{task}", what, returner)
           response = make_request('/', body)
           msg.reply process_response(response)
         end
@@ -164,7 +165,7 @@ module Lita
         if what.nil?
           msg.reply "Missing job name"
         else
-          body = build_local(where, "#{__callee__}.#{task}", what)
+          body = build_local(where, "#{__callee__}.#{task}", what, returner)
           response = make_request('/', body)
           msg.reply process_response(response)
         end
@@ -193,7 +194,7 @@ module Lita
         if what.nil?
           msg.reply "Missing job name"
         else
-          body = build_local(where, "#{__callee__}.#{task}", what)
+          body = build_local(where, "#{__callee__}.#{task}", what, returner)
           response = make_request('/', body)
           msg.reply_privately process_response(response)
         end
@@ -222,6 +223,10 @@ module Lita
 
       def password
         config.password
+      end
+
+      def returner
+        config.returner
       end
 
     end

--- a/lib/lita/utils/payload.rb
+++ b/lib/lita/utils/payload.rb
@@ -3,19 +3,22 @@ require 'json'
 module Utils
   module Payload
 
-    def build_runner(function)
-      JSON.dump({
+    def build_runner(function, returner)
+      s = {
         client: :runner,
         fun: function
-      })
+      }
+      s['ret'] = returner unless returner.nil?
+      JSON.dump(s)
     end
 
-    def build_local(target, function, arg=nil)
+    def build_local(target, function, arg=nil, returner=nil)
       s = {
         client: :local,
         tgt: target,
-        fun: function,
+        fun: function
       }
+      s['ret'] = returner unless returner.nil?
       s['arg'] = [arg] unless arg.nil?
       JSON.dump(s)
     end

--- a/lib/lita/utils/payload.rb
+++ b/lib/lita/utils/payload.rb
@@ -3,7 +3,7 @@ require 'json'
 module Utils
   module Payload
 
-    def build_runner(function, returner)
+    def build_runner(function, returner=nil)
       s = {
         client: :runner,
         fun: function


### PR DESCRIPTION
closes #5 
- `returner` (String) – A Saltstack returner you'd like to use. (uses defau
  lt if unset)
### Example

``` ruby
Lita.configure do |config|
    config.handlers.salt.url = "https://api.example.com"
    config.handlers.salt.username = ENV["SALT_USERNAME"]
    config.handlers.salt.password = ENV["SALT_PASSWORD"]
    config.handlers.salt.returner = "elasticsearch"
end                                                         
```
